### PR TITLE
Enhancement: Add a few more options in initSettings.js, add lib/parseWPImagePath.js

### DIFF
--- a/lib/parseWPImagePath.js
+++ b/lib/parseWPImagePath.js
@@ -1,0 +1,39 @@
+const settings = require('../settings');
+
+function parseWPImagePath(urlpath) {
+  const url = new URL(urlpath);
+  const pathname = url.pathname;
+  const imageSizesPattern = new RegExp('(?:[-_]([0-9]+)x([0-9]+))');
+  const folderPattern = new RegExp('(?:([0-9]+)/([0-9]+))');
+  const folder =
+    (pathname.match(folderPattern) && pathname.match(folderPattern)[0]) ||
+    'images';
+  const filenameUnsplit = pathname
+    .replace(imageSizesPattern, '')
+    .split('/')
+    .pop();
+
+  const filename = filenameUnsplit.split('.')[0];
+  const fileExtension = filenameUnsplit.split('.')[1];
+
+  const search = url.search;
+  const params = new URLSearchParams(search);
+  let intermadiateMeta = '';
+
+  for (let value of params.keys()) {
+    intermadiateMeta = intermadiateMeta + `-${value}-${params.get(value)}`;
+  }
+
+  const cleanUrl = `${settings.site_url}/${folder}/${
+    filename + intermadiateMeta + '.' + fileExtension
+  }`;
+  const result = {
+    originalUrl: urlpath,
+    cleanUrl: cleanUrl,
+    folder: folder,
+    filename: filename + intermadiateMeta + '.' + fileExtension,
+  };
+  return result;
+}
+
+module.exports = parseWPImagePath;


### PR DESCRIPTION
Added a few more options in `initSettings.js` CLI
### Changelog of `initSettings.js`:
- Added new option for selecting `siteID` of wordpress.com sites
- Added a new option for image download directory (the images to be downloaded from wordpress posts)
- Added a new option for the new site URL (example: original url: `https://example_wordpress_site.com/some_posts` should be replaced by the new URL `https://my_new_site_url.com/some_posts` 

### Changelog of `lib/parseWPImagePath.js`:
- Added a raw wordpress.com URL parser.
#### Parser example:
It should parse the URL: `https://example_wordpress_site.com/some_post/some_image.jpg?480x720` to  `https://my_new_site_url.com/some_post/some_image_480_720.jpg` and return 
   ```
originalUrl: https://example_wordpress_site.com/some_post/some_image.jpg?480x720
cleanUrl: https://my_new_site_url.com/some_post/some_image_480_720.jpg
folder: some_post
filename: some_image_480_720
```